### PR TITLE
Comm status card

### DIFF
--- a/src/components/common/CommEventCard.tsx
+++ b/src/components/common/CommEventCard.tsx
@@ -3,15 +3,15 @@ import React from 'react';
 import { CommEvent } from '../../models/CommunicationStatus';
 
 export default function CommStatusDisplay({ event }: { event: CommEvent }) {
-    const typeText = "Received type: " + event.type + '\n';
+    const typeText = "Event to send: " + event.type + '.';
     switch (event.type) {
-        case 'heartbeat':
-            return <p>{typeText + `Indicated event ${event.eventsSinceSubscriptionStart} existed`}</p>
         case 'heartbeat-miss':
         case 'clear':
             return <p>{typeText}</p>
+        case 'heartbeat':
+            return <p>{typeText + ` eventsSinceSubscriptionStart will be ${event.eventsSinceSubscriptionStart}`}</p>
         case 'notify':
         case 'recover':
-            return <p>{typeText + ". Events: " + JSON.stringify(event.events, null, 2)}</p>
+            return <p>{typeText + ` eventsSinceSubscriptionStart will be ${event.eventsSinceSubscriptionStart}` + ". Events to include: " + JSON.stringify(event.events, null, 2)}</p>
     }
 }

--- a/src/components/common/CommEventCard.tsx
+++ b/src/components/common/CommEventCard.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { CommEvent } from '../../models/CommunicationStatus';
+
+export default function CommStatusDisplay({ event }: { event: CommEvent }) {
+    const typeText = "Received type: " + event.type + '\n';
+    switch (event.type) {
+        case 'heartbeat':
+            return <p>{typeText + `Indicated event ${event.eventsSinceSubscriptionStart} existed`}</p>
+        case 'heartbeat-miss':
+        case 'clear':
+            return <p>{typeText}</p>
+        case 'notify':
+        case 'recover':
+            return <p>{typeText + ". Events: " + JSON.stringify(event.events, null, 2)}</p>
+    }
+}

--- a/src/components/common/CommStatusCard.tsx
+++ b/src/components/common/CommStatusCard.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { ReactNode } from 'react';
+
+import { CommState, applyByConnected, applyByMissed, CommEvent, reducer, EventRange } from '../../models/CommunicationStatus';
+
+export default function CommStatusDisplay({ commEvents }: { commEvents: CommEvent[] }) {
+
+    let status: CommState = { type: 'connected', lastReceived: 0 };
+    let error: { error: false } | { error: true, index: number, message: string };
+    error = { error: false };
+
+    commEvents.forEach((event, index) => {
+        if (!error.error) {
+            const result = reducer(status, event);
+            if (result.error) {
+                error = { error: true, index, message: result.message }
+            } else {
+                status = result.commState
+            }
+        }
+    });
+
+    if (!error.error) {
+
+        const eventNodes: ReactNode[] = commEvents.map((event, index) => {
+            const typeText = "Received type: " + event.type + '\n';
+            switch (event.type) {
+                case 'heartbeat':
+                    return <p key={index}>{typeText + `Indicated event ${event.eventsEndRange} existed`}</p>
+                case 'heartbeat-miss':
+                    return <p key={index}>{typeText}</p>
+                case 'notify':
+                case 'recover':
+                    return <p key={index}>{typeText + ". Events: " + JSON.stringify(event.events, null, 2)}</p>
+            }
+        });
+        eventNodes.unshift(<p>{"List of received events"}</p>)
+
+        const { lastReceived, type } = status;
+        return <div>
+            <p>
+                {`Status ${type}. Last received event ${lastReceived}`}
+            </p>
+            <p>
+                {applyByConnected(
+                    status,
+                    "Connected!",
+                    "Not connected..."
+                )}
+            </p>
+            <p>
+                {applyByMissed(
+                    status,
+                    (missingEvents) => {
+                        const ranges: EventRange[] = Array.from(missingEvents);
+                        const nodes: ReactNode[] = ranges.map(range => {
+                            return <pre key={range.endRange}>{JSON.stringify(range, null, 2)}</pre>
+                        });
+                        nodes.unshift(<p>{"Missing events"}</p>)
+                        return <div>{nodes}</div>
+                    },
+                    () => <p>{"No missing events!"}</p>)}
+            </p>
+            <p>
+                <div>{eventNodes}</div>
+            </p>
+        </div>
+    }
+    return <div>{"Encounter error: " + JSON.stringify(error)}</div>
+
+}

--- a/src/components/common/CommStatusCard.tsx
+++ b/src/components/common/CommStatusCard.tsx
@@ -4,11 +4,19 @@ import { ReactNode } from 'react';
 import { CommState, applyByConnected, applyByMissed } from '../../models/CommunicationStatus';
 
 export default function CommStatusDisplay({ commState }: { commState: CommState }) {
-    const { lastReceived, type } = commState;
+    const { lastReceived, type, receivedEvents } = commState;
     return <div>
+        <h3>Events most recently received</h3>
+        <p>
+            {!!receivedEvents
+                ? <pre >{JSON.stringify(commState.receivedEvents, null, 2)}</pre>
+                : <p>Received no events in last event</p>}
+        </p>
+        <h3>Last Received Event ($events counts)</h3>
         <p>
             {`Status ${type}. Last received event ${lastReceived}`}
         </p>
+        <h3>Current connection status</h3>
         <p>
             {applyByConnected(
                 commState,
@@ -16,6 +24,7 @@ export default function CommStatusDisplay({ commState }: { commState: CommState 
                 "Not connected..."
             )}
         </p>
+        <h3>Missing Events (if any)</h3>
         <p>
             {applyByMissed(
                 commState,

--- a/src/components/common/CommStatusCard.tsx
+++ b/src/components/common/CommStatusCard.tsx
@@ -1,71 +1,32 @@
 import React from 'react';
 import { ReactNode } from 'react';
 
-import { CommState, applyByConnected, applyByMissed, CommEvent, reducer, EventRange } from '../../models/CommunicationStatus';
+import { CommState, applyByConnected, applyByMissed } from '../../models/CommunicationStatus';
 
-export default function CommStatusDisplay({ commEvents }: { commEvents: CommEvent[] }) {
-
-    let status: CommState = { type: 'connected', lastReceived: 0 };
-    let error: { error: false } | { error: true, index: number, message: string };
-    error = { error: false };
-
-    commEvents.forEach((event, index) => {
-        if (!error.error) {
-            const result = reducer(status, event);
-            if (result.error) {
-                error = { error: true, index, message: result.message }
-            } else {
-                status = result.commState
-            }
-        }
-    });
-
-    if (!error.error) {
-
-        const eventNodes: ReactNode[] = commEvents.map((event, index) => {
-            const typeText = "Received type: " + event.type + '\n';
-            switch (event.type) {
-                case 'heartbeat':
-                    return <p key={index}>{typeText + `Indicated event ${event.eventsEndRange} existed`}</p>
-                case 'heartbeat-miss':
-                    return <p key={index}>{typeText}</p>
-                case 'notify':
-                case 'recover':
-                    return <p key={index}>{typeText + ". Events: " + JSON.stringify(event.events, null, 2)}</p>
-            }
-        });
-        eventNodes.unshift(<p>{"List of received events"}</p>)
-
-        const { lastReceived, type } = status;
-        return <div>
-            <p>
-                {`Status ${type}. Last received event ${lastReceived}`}
-            </p>
-            <p>
-                {applyByConnected(
-                    status,
-                    "Connected!",
-                    "Not connected..."
-                )}
-            </p>
-            <p>
-                {applyByMissed(
-                    status,
-                    (missingEvents) => {
-                        const ranges: EventRange[] = Array.from(missingEvents);
-                        const nodes: ReactNode[] = ranges.map(range => {
-                            return <pre key={range.endRange}>{JSON.stringify(range, null, 2)}</pre>
-                        });
-                        nodes.unshift(<p>{"Missing events"}</p>)
-                        return <div>{nodes}</div>
-                    },
-                    () => <p>{"No missing events!"}</p>)}
-            </p>
-            <p>
-                <div>{eventNodes}</div>
-            </p>
-        </div>
-    }
-    return <div>{"Encounter error: " + JSON.stringify(error)}</div>
-
+export default function CommStatusDisplay({ commState }: { commState: CommState }) {
+    const { lastReceived, type } = commState;
+    return <div>
+        <p>
+            {`Status ${type}. Last received event ${lastReceived}`}
+        </p>
+        <p>
+            {applyByConnected(
+                commState,
+                "Connected!",
+                "Not connected..."
+            )}
+        </p>
+        <p>
+            {applyByMissed(
+                commState,
+                (missingEvents) => {
+                    const nodes: ReactNode[] = missingEvents.map(range => {
+                        return <pre key={range.endRange}>{JSON.stringify(range, null, 2)}</pre>
+                    });
+                    nodes.unshift(<p>{"Missing events"}</p>)
+                    return <div>{nodes}</div>
+                },
+                () => <p>{"No missing events!"}</p>)}
+        </p>
+    </div>
 }

--- a/src/components/playground/CommStatusPlayground.tsx
+++ b/src/components/playground/CommStatusPlayground.tsx
@@ -1,0 +1,203 @@
+import React, { useState } from 'react';
+
+import {
+  Tabs, Tab, TabId,
+  Button, Card, H6, HTMLSelect, InputGroup, Spinner, FormGroup, Switch,
+} from '@blueprintjs/core';
+
+import { ContentPaneProps } from '../../models/ContentPaneProps';
+import { DataCardInfo } from '../../models/DataCardInfo';
+// import { SingleRequestData } from '../../models/RequestData';
+import DataCard from '../basic/DataCard';
+import { DataCardStatus } from '../../models/DataCardStatus';
+import { CommEvent } from '../../models/CommunicationStatus';
+import CommStatusCard from '../common/CommStatusCard';
+
+export interface CommStatusPgProps {
+  paneProps: ContentPaneProps,
+  status: DataCardStatus
+  //   data: SingleRequestData[]
+}
+
+/** Component representing the Playground CommStatus card */
+export default function CommStatusPg(props: CommStatusPgProps) {
+
+  const info: DataCardInfo = {
+    id: 'pg_commStatus',
+    heading: 'Manually trigger communication events',
+    description: '',
+    optional: true,
+  };
+
+  type TabTypes = 'heartbeat' | 'heartbeat-miss' | '$events' | 'notification';
+  const [selectedTabId, setSelectedTabId] = useState<TabTypes>('notification');
+  const [commEvents, setCommEvents] = useState<CommEvent[]>([]);
+  const [nextEndRange, setNextEndRange] = useState<number>(0);
+  const [nextCount, setNextCount] = useState<number>(0);
+
+  /** Process HTML events for the patient id (update state for managed) */
+  function handleNextEndRangeChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setNextEndRange(Number.parseInt(event.target.value) || 0);
+  }
+
+  /** Process HTML events for the patient id (update state for managed) */
+  function handleNextCountChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setNextCount(Number.parseInt(event.target.value) || 0);
+  }
+
+  /** Function to handle tab selection changes */
+  function handleTabChange(navbarTabId: TabId | TabTypes) {
+    switch (navbarTabId) {
+      case 'heartbeat':
+      case 'heartbeat-miss':
+      case '$events':
+      case 'notification':
+        setSelectedTabId(navbarTabId);
+        break;
+      default:
+        window.alert('Invalid tab :' + navbarTabId);
+        break;
+    }
+  }
+
+  // return card with search and create options
+  return (
+    <DataCard
+      info={info}
+      data={[]}
+      paneProps={props.paneProps}
+      status={props.status}
+    >
+      <Tabs
+        animate={true}
+        id='tabsPlaygComms'
+        vertical={false}
+        selectedTabId={selectedTabId}
+        onChange={handleTabChange}
+      >
+        <Tab
+          id='heartbeat'
+          title='heartbeat'
+          panel={
+            <Card>
+              <FormGroup
+                label='heartbeat data'
+                helperText='The eventsSinceSubscriptionStart value for this heartbeat'
+                labelFor='heartbeat-endRange'
+              >
+                <InputGroup
+                  id='heartbeat-endRange'
+                  onChange={handleNextEndRangeChange}
+                />
+              </FormGroup>
+            </Card>
+          }
+        />
+        <Tab
+          id='notification'
+          title='notification'
+          panel={
+            <Card>
+              <FormGroup
+                label='notification latest event'
+                helperText='The eventsSinceSubscriptionStart value for this notification'
+                labelFor='notification-endRange'
+              >
+                <InputGroup
+                  id='notification-endRange'
+                  onChange={handleNextEndRangeChange}
+                />
+              </FormGroup>
+              <FormGroup
+                label='notification event count'
+                helperText='The eventsInNotification value for this notification'
+                labelFor='notification-count'
+              >
+                <InputGroup
+                  id='notification-count'
+                  onChange={handleNextCountChange}
+                />
+              </FormGroup>
+            </Card>
+          }
+        />
+        <Tab
+          id='$events'
+          title='$events'
+          panel={
+            <Card>
+            <FormGroup
+              label='$events latest event'
+              helperText='The eventsSinceSubscriptionStart value for this $events call'
+              labelFor='$events-endRange'
+            >
+              <InputGroup
+                id='$events-endRange'
+                onChange={handleNextEndRangeChange}
+              />
+            </FormGroup>
+            <FormGroup
+              label='$events event count'
+              helperText='The eventsInNotification value for this $events call'
+              labelFor='$events-count'
+            >
+              <InputGroup
+                id='$events-count'
+                onChange={handleNextCountChange}
+              />
+            </FormGroup>
+          </Card>
+          }
+        />
+        <Tab
+          id='heartbeat-miss'
+          title='heartbeat missed'
+          panel={
+            <Card>
+              <strong>No input needed. Click submit to send</strong>
+            </Card>
+          }
+        />
+      </Tabs>
+      <Button
+        onClick={() => {
+          const nextEvent = ((): CommEvent => {
+            switch (selectedTabId) {
+              case 'heartbeat':
+                return {
+                  type: 'heartbeat',
+                  eventsEndRange: nextEndRange
+                }
+              case 'heartbeat-miss':
+                return {
+                  type: 'heartbeat-miss'
+                }
+              case '$events':
+                return {
+                  type: 'recover',
+                  events: {
+                    count: nextCount,
+                    endRange: nextEndRange
+                  }
+                }
+              case 'notification':
+                return {
+                  type: 'recover',
+                  events: {
+                    count: nextCount,
+                    endRange: nextEndRange
+                  }
+                }
+            }
+          })()
+          setCommEvents(commEvents.concat(nextEvent));
+        }}
+        style={{ margin: 5 }}
+      >
+        Issue Event
+      </Button>
+      <Button onClick={() => {setCommEvents([])}}>Reset status</Button>
+      <CommStatusCard commEvents={commEvents} />
+    </DataCard>
+  );
+}

--- a/src/components/playground/CommStatusPlayground.tsx
+++ b/src/components/playground/CommStatusPlayground.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useReducer } from 'react';
 
 import {
   Tabs, Tab, TabId,
@@ -10,8 +10,9 @@ import { DataCardInfo } from '../../models/DataCardInfo';
 // import { SingleRequestData } from '../../models/RequestData';
 import DataCard from '../basic/DataCard';
 import { DataCardStatus } from '../../models/DataCardStatus';
-import { CommEvent } from '../../models/CommunicationStatus';
+import { CommEvent, reducer, CommState } from '../../models/CommunicationStatus';
 import CommStatusCard from '../common/CommStatusCard';
+import CommEventCard from '../common/CommEventCard';
 
 export interface CommStatusPgProps {
   paneProps: ContentPaneProps,
@@ -29,20 +30,23 @@ export default function CommStatusPg(props: CommStatusPgProps) {
     optional: true,
   };
 
-  type TabTypes = 'heartbeat' | 'heartbeat-miss' | '$events' | 'notification';
   const [selectedTabId, setSelectedTabId] = useState<TabTypes>('notification');
   const [commEvents, setCommEvents] = useState<CommEvent[]>([]);
+  const [commState, dispatchCommEvent] = useReducer(reducer, { type: 'connected', lastReceived: 0 });
+  const [nextEventsSinceSubscriptionStart, setNextEventsSinceSubscriptionStart] = useState<number>(0);
   const [nextEndRange, setNextEndRange] = useState<number>(0);
   const [nextCount, setNextCount] = useState<number>(0);
 
-  /** Process HTML events for the patient id (update state for managed) */
   function handleNextEndRangeChange(event: React.ChangeEvent<HTMLInputElement>) {
     setNextEndRange(Number.parseInt(event.target.value) || 0);
   }
 
-  /** Process HTML events for the patient id (update state for managed) */
   function handleNextCountChange(event: React.ChangeEvent<HTMLInputElement>) {
     setNextCount(Number.parseInt(event.target.value) || 0);
+  }
+
+  function handleNextEventsSinceSubscriptionStartChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setNextEventsSinceSubscriptionStart(Number.parseInt(event.target.value) || 0);
   }
 
   /** Function to handle tab selection changes */
@@ -83,11 +87,11 @@ export default function CommStatusPg(props: CommStatusPgProps) {
               <FormGroup
                 label='heartbeat data'
                 helperText='The eventsSinceSubscriptionStart value for this heartbeat'
-                labelFor='heartbeat-endRange'
+                labelFor='heartbeat-sinceStart'
               >
                 <InputGroup
-                  id='heartbeat-endRange'
-                  onChange={handleNextEndRangeChange}
+                  id='heartbeat-sinceStart'
+                  onChange={handleNextEventsSinceSubscriptionStartChange}
                 />
               </FormGroup>
             </Card>
@@ -99,8 +103,18 @@ export default function CommStatusPg(props: CommStatusPgProps) {
           panel={
             <Card>
               <FormGroup
+                label='notification eventsSinceSubscriptionStart'
+                helperText='The eventsSinceSubscriptionStart value for the subscription'
+                labelFor='notification-sinceStart'
+              >
+                <InputGroup
+                  id='notification-sinceStart'
+                  onChange={handleNextEventsSinceSubscriptionStartChange}
+                />
+              </FormGroup>
+              <FormGroup
                 label='notification latest event'
-                helperText='The eventsSinceSubscriptionStart value for this notification'
+                helperText='The eventNumber for the last included event in this notification'
                 labelFor='notification-endRange'
               >
                 <InputGroup
@@ -126,27 +140,37 @@ export default function CommStatusPg(props: CommStatusPgProps) {
           title='$events'
           panel={
             <Card>
-            <FormGroup
-              label='$events latest event'
-              helperText='The eventsSinceSubscriptionStart value for this $events call'
-              labelFor='$events-endRange'
-            >
-              <InputGroup
-                id='$events-endRange'
-                onChange={handleNextEndRangeChange}
-              />
-            </FormGroup>
-            <FormGroup
-              label='$events event count'
-              helperText='The eventsInNotification value for this $events call'
-              labelFor='$events-count'
-            >
-              <InputGroup
-                id='$events-count'
-                onChange={handleNextCountChange}
-              />
-            </FormGroup>
-          </Card>
+              <FormGroup
+                label='$events latest event'
+                helperText='The eventsSinceSubscriptionStart value for the subscription'
+                labelFor='$events-sinceStart'
+              >
+                <InputGroup
+                  id='$events-sinceStart'
+                  onChange={handleNextEventsSinceSubscriptionStartChange}
+                />
+              </FormGroup>
+              <FormGroup
+                label='$events latest event'
+                helperText='The eventNumber for the last included event in this payload'
+                labelFor='$events-endRange'
+              >
+                <InputGroup
+                  id='$events-endRange'
+                  onChange={handleNextEndRangeChange}
+                />
+              </FormGroup>
+              <FormGroup
+                label='$events event count'
+                helperText='The eventsInNotification value for this $events call'
+                labelFor='$events-count'
+              >
+                <InputGroup
+                  id='$events-count'
+                  onChange={handleNextCountChange}
+                />
+              </FormGroup>
+            </Card>
           }
         />
         <Tab
@@ -161,43 +185,63 @@ export default function CommStatusPg(props: CommStatusPgProps) {
       </Tabs>
       <Button
         onClick={() => {
-          const nextEvent = ((): CommEvent => {
-            switch (selectedTabId) {
-              case 'heartbeat':
-                return {
-                  type: 'heartbeat',
-                  eventsEndRange: nextEndRange
-                }
-              case 'heartbeat-miss':
-                return {
-                  type: 'heartbeat-miss'
-                }
-              case '$events':
-                return {
-                  type: 'recover',
-                  events: {
-                    count: nextCount,
-                    endRange: nextEndRange
-                  }
-                }
-              case 'notification':
-                return {
-                  type: 'recover',
-                  events: {
-                    count: nextCount,
-                    endRange: nextEndRange
-                  }
-                }
-            }
-          })()
-          setCommEvents(commEvents.concat(nextEvent));
+          const nextEvent = getCommEvent(selectedTabId, {
+            eventsSinceSubscriptionStart: nextEventsSinceSubscriptionStart,
+            count: nextCount,
+            endRange: nextEndRange
+          });
+          dispatchCommEvent(nextEvent);
         }}
         style={{ margin: 5 }}
       >
         Issue Event
       </Button>
-      <Button onClick={() => {setCommEvents([])}}>Reset status</Button>
-      <CommStatusCard commEvents={commEvents} />
+      <Button onClick={() => dispatchCommEvent({ type: 'clear' })}>Reset status</Button>
+      <CommEventCard event={getCommEvent(selectedTabId, {
+        eventsSinceSubscriptionStart: nextEventsSinceSubscriptionStart,
+        count: nextCount,
+        endRange: nextEndRange
+      })} />
+      <CommStatusCard commState={commState} />
     </DataCard>
   );
+}
+
+type TabTypes = 'heartbeat' | 'heartbeat-miss' | '$events' | 'notification';
+type EventInfo = {
+  eventsSinceSubscriptionStart: number,
+  endRange: number,
+  count: number
+}
+const getCommEvent = (selectedTabId: TabTypes,
+  { count, endRange, eventsSinceSubscriptionStart }: EventInfo): CommEvent => {
+  switch (selectedTabId) {
+    case 'heartbeat':
+      return {
+        type: 'heartbeat',
+        eventsSinceSubscriptionStart
+      }
+    case 'heartbeat-miss':
+      return {
+        type: 'heartbeat-miss'
+      }
+    case '$events':
+      return {
+        type: 'recover',
+        events: {
+          count,
+          endRange
+        },
+        eventsSinceSubscriptionStart
+      }
+    case 'notification':
+      return {
+        type: 'notify',
+        events: {
+          count,
+          endRange
+        },
+        eventsSinceSubscriptionStart
+      }
+  }
 }

--- a/src/components/playground/CommStatusPlayground.tsx
+++ b/src/components/playground/CommStatusPlayground.tsx
@@ -31,7 +31,6 @@ export default function CommStatusPg(props: CommStatusPgProps) {
   };
 
   const [selectedTabId, setSelectedTabId] = useState<TabTypes>('notification');
-  const [commEvents, setCommEvents] = useState<CommEvent[]>([]);
   const [commState, dispatchCommEvent] = useReducer(reducer, { type: 'connected', lastReceived: 0 });
   const [nextEventsSinceSubscriptionStart, setNextEventsSinceSubscriptionStart] = useState<number>(0);
   const [nextEndRange, setNextEndRange] = useState<number>(0);

--- a/src/components/playground/PlaygroundPane.tsx
+++ b/src/components/playground/PlaygroundPane.tsx
@@ -17,6 +17,7 @@ import SubscriptionPlayground from './SubscriptionPlayground';
 import { EndpointRegistration } from '../../models/EndpointRegistration';
 import EndpointPlayground from './EndpointPlayground';
 import WebsocketPlayground from './WebsocketPlayground';
+import CommStatusPlayground from './CommStatusPlayground';
 import { ApiResponse, ApiHelper } from '../../util/ApiHelper';
 // import { KeySelectionInfo } from '../../models/KeySelectionInfo';
 import EncountersPlayground from './EncountersPlayground';
@@ -56,6 +57,8 @@ export default function PlaygroundPane(props: ContentPaneProps) {
 
 	const [websocketData, setWebsocketData] = useState<SingleRequestData[]>([]);
 	const [websocketStatus, setWebsocketStatus] = useState<DataCardStatus>(_statusAvailable);
+
+	const [commStatusStatus, setCommStatusStatus] = useState<DataCardStatus>(_statusAvailable);
 
 	const [pendingMessages, setPendingMessages] = useState<string[]>([]);
 
@@ -116,6 +119,7 @@ export default function PlaygroundPane(props: ContentPaneProps) {
 	}
 
 	/** Callback function to process ClientHost messages */
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	function handleHostMessage(message: string) {
 		// check for an R4-Websocket ping
 		if (message.startsWith('ping')) {
@@ -338,6 +342,13 @@ export default function PlaygroundPane(props: ContentPaneProps) {
 				setData={setWebsocketData}
 				subscriptions={subscriptions}
 				handleHostMessage={queueMessage}
+				/>
+
+			{/* Communication Status Playground Card */}
+			<CommStatusPlayground
+				key='playground_commStatus'
+				paneProps={props}
+				status={commStatusStatus}
 				/>
 
 			<EncountersPlayground

--- a/src/models/CommunicationStatus.ts
+++ b/src/models/CommunicationStatus.ts
@@ -1,0 +1,514 @@
+// Core Types
+export type EventRange = { endRange: number, count: number };
+
+// Event Types
+type BaseEvent<T extends string> = {
+    type: T,
+    events: EventRange
+}
+type RecoverEvent = BaseEvent<'recover'>;
+type NotifyEvent = BaseEvent<'notify'>;
+type HeartBeatEvent = { type: 'heartbeat', eventsEndRange: number }
+type HeartBeatMissEvent = { type: 'heartbeat-miss' }
+export type CommEvent = RecoverEvent | NotifyEvent | HeartBeatEvent | HeartBeatMissEvent;
+
+// State Types
+type BaseState<T extends string> = {
+    type: T,
+    lastReceived: number
+};
+
+type EventGenerator = Generator<EventRange, number>;
+type MissingEventsState<T extends string> = BaseState<T> & {
+    missingEvents: EventGenerator
+}
+type Connected = BaseState<'connected'>;
+type MissedMessages = MissingEventsState<'missed-messages'>;
+type BrokenConnection = BaseState<'broken-connection'>;
+type BrokenAndMissed = MissingEventsState<'broken-and-missed'>;
+export type CommState = Connected | MissedMessages | BrokenConnection | BrokenAndMissed;
+
+type CommStateResult = {
+    error: false,
+    commState: CommState
+} | {
+    error: true,
+    message: string
+}
+
+export function reducer(state: CommState, action: CommEvent): CommStateResult {
+    switch (action.type) {
+        case 'heartbeat-miss':
+            return {
+                error: false,
+                commState: handleHeartbeatMiss(state)
+            };
+        case 'heartbeat':
+            return action.eventsEndRange < 0
+                ? { error: true, message: 'eventsSinceSubscriptionStart cannot be less than 0: ' + action.eventsEndRange }
+                : { error: false, commState: handleHeartbeat(state, action.eventsEndRange)}
+        case 'notify':
+        case 'recover':
+            const { events } = action;
+            const maybeError: string | undefined =
+                events.endRange < 0
+                    ? 'eventsSinceSubscriptionStart cannot be less than 0: ' + events.endRange
+                    : (events.endRange - events.count) < 0
+                        ? `event indicated negative events. eventsSinceSubscriptionStart=${events.endRange} and eventsInNotification=${events.count}`
+                        : events.count < 0
+                            ? 'eventsInNotification cannt be less than 0: ' + events.count
+                            : undefined;
+            // Both can remove missing events
+            if (!!maybeError) {
+                return {
+                    error: true,
+                    message: maybeError
+                }
+            } else {
+                const eventStart = events.endRange - events.count;
+                const maybeNewMissing =
+                    applyToRightLedge<EventRange | undefined>(
+                        { endRange: state.lastReceived, count: state.lastReceived },
+                        events,
+                        // Full overlap, no missing
+                        () => undefined,
+                        // Missing range
+                        (count) => { return { count, endRange: eventStart } },
+                        // Left overhang, we'll take care of this on removal
+                        (_) => undefined
+                    );
+                const maybePriorMissing = applyByMissed<GeneratorRemoveResult>(
+                    state,
+                    (priorMissing) => tryRemoveRangeFromGenerator(priorMissing, events),
+                    () => { return { empty: true } }
+                );
+                const maybeMissing: EventGenerator | undefined = !!maybeNewMissing
+                    ? maybePriorMissing.empty
+                        ? createGenerator(maybeNewMissing) : addRangeToGenerator(maybePriorMissing.generator, maybeNewMissing)
+                    : maybePriorMissing.empty
+                        ? undefined : maybePriorMissing.generator;
+                
+                switch (action.type) {
+                    case 'notify':
+                        return {
+                            error: false,
+                            commState: handleNotify(state, events, maybeMissing)
+                        };
+                    case 'recover':
+                        return {
+                            error: false,
+                            commState: handleRecover(state, events, maybeMissing)
+                        };
+                }
+            }
+    }
+}
+
+function handleNotify(state: CommState, events: EventRange, maybeMissing?: EventGenerator): CommState {
+    // Only notify can set a new lastReceived
+    // If notification indicates there are more events than we have, set to missed-messages
+    // Can return missed-messages or connected, 
+    // or the initial state (with revised missedMesages) if it's a replay
+    const { lastReceived: priorLastReceived } = state;
+    if (events.endRange > priorLastReceived) {
+        // Connected!
+        const lastReceived = events.endRange;
+        return !!maybeMissing
+            ? {
+                type: 'missed-messages',
+                lastReceived,
+                missingEvents: maybeMissing
+            }
+            : {
+                type: 'connected',
+                lastReceived
+            }
+    } else {
+        // We didn't fix the connection, but it may have been connected
+        return editPreservingConnection(state, priorLastReceived, maybeMissing);
+    }
+}
+
+function handleRecover(state: CommState, events: EventRange, maybeMissing?: EventGenerator): CommState {
+    // Cannot reset lastReceived, or set connection status to connected
+    // Can only modify missingEvents, or break connection if we're missing something
+    const { lastReceived } = state;
+    if (events.endRange > lastReceived) {
+        return !!maybeMissing
+            ? {
+                type: 'broken-and-missed',
+                lastReceived,
+                missingEvents: maybeMissing
+            }
+            : {
+                type: 'broken-connection',
+                lastReceived
+            }
+    } else {
+        // We didn't break the connection, but it may be broken
+        return editPreservingConnection(state, lastReceived, maybeMissing);
+    }
+}
+
+function editPreservingConnection(state: CommState, lastReceived: number, maybeMissing?: EventGenerator): CommState {
+    return !!maybeMissing
+        ? applyByConnected<CommState>(
+            state,
+            // Connected and missing
+            {
+                type: 'missed-messages',
+                lastReceived,
+                missingEvents: maybeMissing
+            },
+            // broken and missing
+            {
+                type: 'broken-and-missed',
+                lastReceived,
+                missingEvents: maybeMissing
+            })
+        : applyByConnected<CommState>(
+            state,
+            // Connected and not missing
+            {
+                type: 'connected',
+                lastReceived
+            },
+            // broken and not missing
+            {
+                type: 'broken-connection',
+                lastReceived
+            });
+}
+
+function handleHeartbeatMiss(state: CommState): CommState {
+    return state.type === 'connected' || state.type === 'broken-connection'
+        ? { type: 'broken-connection', lastReceived: state.lastReceived }
+        : { type: 'broken-and-missed', lastReceived: state.lastReceived, missingEvents: state.missingEvents }
+}
+
+function handleHeartbeat(state: CommState, eventsEndRange: number): CommState {
+    const diffWithLast = eventsEndRange - state.lastReceived;
+    const lastReceived = state.lastReceived;
+    // Reconnects any state, but may have new missed range
+    if (diffWithLast >= 0) {
+        // Reconnects  
+        if (diffWithLast === 0) {
+            const lastReceived = state.lastReceived;
+            return applyByMissed<CommState>(
+                state,
+                (missingEvents) => {
+                    return {
+                        type: 'missed-messages',
+                        lastReceived,
+                        missingEvents
+                    }
+                },
+                () => {
+                    return {
+                        type: 'connected',
+                        lastReceived
+                    }
+                });
+            // Reconnects with new miss
+        } else {
+            const newMissed: EventRange = {
+                endRange: eventsEndRange,
+                count: diffWithLast
+            };
+            const missingEvents = applyByMissed<EventGenerator>(
+                state,
+                (priorMisses) => addRangeToGenerator(priorMisses, newMissed),
+                () => createGenerator(newMissed)
+            );
+            return {
+                type: 'missed-messages',
+                lastReceived,
+                missingEvents
+            };
+        }
+        // Replayed heartbeat
+    } else {
+        return state;
+    }
+}
+
+export function applyByConnected<T>(
+    state: CommState,
+    connected: T,
+    disconnected: T
+): T {
+    switch (state.type) {
+        case 'connected':
+        case 'missed-messages':
+            return connected;
+        case 'broken-connection':
+        case 'broken-and-missed':
+            return disconnected
+    }
+}
+
+export function applyByMissed<T>(
+    state: CommState,
+    applyMissed: (missed: EventGenerator) => T,
+    applyNoMiss: () => T
+): T {
+    switch (state.type) {
+        case 'connected':
+        case 'broken-connection':
+            return applyNoMiss();
+        case 'missed-messages':
+        case 'broken-and-missed':
+            return applyMissed(state.missingEvents);
+    }
+}
+
+function* createGenerator(create: EventRange): EventGenerator {
+    yield create;
+    return create.count;
+}
+
+function* addRangeToGenerator(existing: EventGenerator, add: EventRange): EventGenerator {
+    let result = existing.next();
+    while (!result.done) {
+        yield result.value;
+        result = existing.next();
+    }
+    yield add;
+    return result.value + add.count;
+}
+
+type EmptyGenerator = {
+    empty: true
+}
+type NonemptyGenerator = {
+    empty: false,
+    generator: EventGenerator
+}
+type GeneratorRemoveResult = EmptyGenerator | NonemptyGenerator;
+
+function tryRemoveRangeFromGenerator(existing: EventGenerator, remove: EventRange): GeneratorRemoveResult {
+    const newGenerator = removeRangeFromGenerator(existing, remove);
+    const firstEntry = newGenerator.next();
+    return !!firstEntry.done
+        ? { empty: true }
+        : { empty: false, generator: removeRangeFromGenerator(existing, remove) }
+};
+
+function* removeRangeFromGenerator(existing: EventGenerator, remove: EventRange): EventGenerator {
+    let result = existing.next();
+    // Copy input, make mutable while we carve away
+    let toRemove: EventRange | undefined = { ...remove };
+    // Keep track of removals for aggregate count
+    let removalCount: number = 0;
+    while (!result.done) {
+        const range = result.value;
+        if (typeof toRemove !== 'undefined') {
+            const { removal, yieldedRange } = removeRangeForward(range, toRemove);
+            switch (removal.type) {
+                case 'none':
+                    break;
+                case 'partial':
+                    const { newRemove, count } = removal;
+                    removalCount = removalCount + count;
+                    toRemove = newRemove;
+                    break;
+                case 'full':
+                    removalCount = removalCount + removal.count;
+                    break;
+            }
+
+            switch (yieldedRange.type) {
+                case 'none':
+                    break;
+                case 'one':
+                    yield yieldedRange.newRange;
+                    break;
+                case 'two':
+                    const { firstRange, secondRange } = yieldedRange;
+                    yield firstRange;
+                    yield secondRange;
+                    break;
+            }
+        } else {
+            yield result.value
+        }
+        result = existing.next();
+    }
+    return result.value - removalCount;
+}
+
+// Types for removals
+type RemovalWithCount = {
+    count: number
+}
+type NoRemoval = {
+    type: 'none'
+}
+type FullRemoval = RemovalWithCount & {
+    type: 'full'
+}
+type PartialRemoval = RemovalWithCount & {
+    type: 'partial',
+    newRemove: EventRange
+}
+type Removal = NoRemoval | FullRemoval | PartialRemoval;
+
+// Types for yielded ranges
+type NoRange = {
+    type: 'none'
+}
+type OneRange = {
+    type: 'one'
+    newRange: EventRange
+}
+type TwoRanges = {
+    type: 'two',
+    firstRange: EventRange,
+    secondRange: EventRange
+}
+type YieldedRange = NoRange | OneRange | TwoRanges;
+
+// Type for RemovalResult
+type RemovalResult = {
+    yieldedRange: YieldedRange,
+    removal: Removal
+}
+
+function applyToRightLedge<T>(
+    range: EventRange,
+    remove: EventRange,
+    applyZero: () => T,
+    applyPositive: (value: number) => T,
+    applyNegative: (absolute: number) => T
+): T {
+    const rightLedge = remove.endRange - range.endRange;
+    if (rightLedge === 0) {
+        return applyZero();
+    } else if (rightLedge > 0) {
+        return applyPositive(rightLedge);
+    } else {
+        return applyNegative(-rightLedge);
+    }
+}
+
+function removeRangeForward(range: EventRange, remove: EventRange): RemovalResult {
+    const startRange = range.endRange - range.count;
+    const startRemove = remove.endRange - remove.count;
+    // Check if it's an early or late miss
+    if ((remove.endRange < startRange) || (startRemove > range.endRange)) {
+        return {
+            removal: {
+                type: 'none'
+            },
+            yieldedRange: {
+                type: 'one',
+                newRange: range
+            }
+        }
+        // Else there's an overlap. Start searching from the left
+    } else {
+        // Check if removal overlaps left of range
+        if (startRemove <= startRange) {
+            return applyToRightLedge<RemovalResult>(range, remove,
+                // No leftover, complete removal
+                () => {
+                    return {
+                        removal: {
+                            type: 'full',
+                            count: range.count //Use range b/c of left overhang
+                        },
+                        yieldedRange: {
+                            type: 'none'
+                        }
+                    }
+                },
+                // Partial removal, no yield 
+                (val) => {
+                    return {
+                        removal: {
+                            type: 'partial',
+                            count: range.count,
+                            newRemove: {
+                                count: val,
+                                endRange: remove.endRange
+                            }
+                        },
+                        yieldedRange: {
+                            type: 'none'
+                        }
+                    }
+                },
+                // Full removal, yield single section
+                (abs) => {
+                    return {
+                        removal: {
+                            type: 'full',
+                            count: remove.endRange - startRange
+                        },
+                        yieldedRange: {
+                            type: 'one',
+                            newRange: {
+                                endRange: range.endRange,
+                                count: abs
+                            }
+                        }
+                    }
+                });
+
+            // If it doesn't, we know it's not a miss, but will have at least one newRange
+        } else {
+            const newRange: EventRange = {
+                endRange: startRemove,
+                count: startRemove - startRange
+            }
+            return applyToRightLedge<RemovalResult>(range, remove,
+                // Full removal with single yielded range
+                () => {
+                    return {
+                        removal: {
+                            type: 'full',
+                            count: remove.count //Use remove b/c no left overhang
+                        },
+                        yieldedRange: {
+                            type: 'one',
+                            newRange
+                        }
+                    }
+                },
+                // Partial removal, single yield 
+                (val) => {
+                    return {
+                        removal: {
+                            type: 'partial',
+                            count: range.endRange - startRemove,
+                            newRemove: {
+                                count: val,
+                                endRange: remove.endRange
+                            }
+                        },
+                        yieldedRange: {
+                            type: 'one',
+                            newRange
+                        }
+                    }
+                },
+                // Full removal, yield two side sections
+                (abs) => {
+                    return {
+                        removal: {
+                            type: 'full',
+                            count: remove.count
+                        },
+                        yieldedRange: {
+                            type: 'two',
+                            secondRange: {
+                                endRange: range.endRange,
+                                count: abs
+                            },
+                            firstRange: newRange
+                        }
+                    }
+                });
+        }
+    }
+}

--- a/src/models/CommunicationStatus.ts
+++ b/src/models/CommunicationStatus.ts
@@ -1,26 +1,29 @@
-// Core Types
-export type EventRange = { endRange: number, count: number };
+import { EventRange, EventList, removeRangeFromList, getStart } from './EventRange';
 
 // Event Types
 type BaseEvent<T extends string> = {
     type: T,
-    events: EventRange
+    eventsSinceSubscriptionStart: number
 }
-type RecoverEvent = BaseEvent<'recover'>;
-type NotifyEvent = BaseEvent<'notify'>;
-type HeartBeatEvent = { type: 'heartbeat', eventsEndRange: number }
+type EventWithEvents<T extends string> = BaseEvent<T> & {
+    events: EventRange
+};
+type RecoverEvent = EventWithEvents<'recover'>;
+type NotifyEvent = EventWithEvents<'notify'>;
+type HeartBeatEvent = BaseEvent<'heartbeat'>;
 type HeartBeatMissEvent = { type: 'heartbeat-miss' }
-export type CommEvent = RecoverEvent | NotifyEvent | HeartBeatEvent | HeartBeatMissEvent;
+type ClearState = { type: 'clear' };
+export type CommEvent = RecoverEvent | NotifyEvent | HeartBeatEvent | HeartBeatMissEvent | ClearState;
 
 // State Types
 type BaseState<T extends string> = {
     type: T,
-    lastReceived: number
+    lastReceived: number,
+    receivedEvents?: EventList
 };
 
-type EventGenerator = Generator<EventRange, number>;
 type MissingEventsState<T extends string> = BaseState<T> & {
-    missingEvents: EventGenerator
+    missingEvents: EventList
 }
 type Connected = BaseState<'connected'>;
 type MissedMessages = MissingEventsState<'missed-messages'>;
@@ -28,208 +31,162 @@ type BrokenConnection = BaseState<'broken-connection'>;
 type BrokenAndMissed = MissingEventsState<'broken-and-missed'>;
 export type CommState = Connected | MissedMessages | BrokenConnection | BrokenAndMissed;
 
-type CommStateResult = {
-    error: false,
-    commState: CommState
-} | {
-    error: true,
-    message: string
+export function reducer(state: CommState, action: CommEvent): CommState {
+    function returnState(
+        isConnected: boolean,
+        lastReceived: number,
+        missingEvents?: EventList,
+        receivedEvents?: EventList
+    ): CommState {
+        return isConnected
+            ? !!missingEvents
+                ? { type: 'missed-messages', missingEvents, receivedEvents, lastReceived }
+                : { type: 'connected', receivedEvents, lastReceived }
+            : !!missingEvents
+                ? { type: 'broken-and-missed', lastReceived, missingEvents, receivedEvents }
+                : { type: 'broken-connection', lastReceived, receivedEvents }
+    };
+    if (action.type === 'clear') {
+        return { type: 'connected', lastReceived: 0 }
+    } else if (action.type === 'heartbeat-miss') {
+        return applyByMissed<CommState>(state, (missingEvents) => {
+            return {
+                type: 'broken-and-missed',
+                lastReceived: state.lastReceived,
+                missingEvents
+            }
+        }, () => {
+            return {
+                type: 'broken-connection',
+                lastReceived: state.lastReceived
+            }
+        });
+    } else {
+        const lastKnown = applyByMissed(state, (missingEvents) => {
+            return checkLastKnown(missingEvents, state.lastReceived)
+        }, () => state.lastReceived);
+        const sinceStartToKnown = action.eventsSinceSubscriptionStart - lastKnown;
+        const maybeMissingEvents = checkNewMissed(state.lastReceived,
+            action.eventsSinceSubscriptionStart,
+            applyByMissed(state, missed => missed, () => undefined));
+        if (sinceStartToKnown < 0) {
+            // Get the new missing (and received) events 
+            const { missingEvents, receivedEvents } = addEventsSimple(action, maybeMissingEvents);
+            return returnState(
+                applyByConnected(state, true, false),
+                getNewLastReceived(action, state),
+                missingEvents,
+                receivedEvents
+            )
+        } else if (sinceStartToKnown === 0) {
+            // Get the new missing (and received) events
+            const { missingEvents, receivedEvents } = addEventsSimple(action, maybeMissingEvents);
+            return returnState(
+                action.type !== 'recover',
+                getNewLastReceived(action, state),
+                missingEvents,
+                receivedEvents
+            )
+        } else {
+            // TODO: What happens if there is a gap in what's returned?
+            // Ex: sinceStart is 38, but we're given just 37 in body the below breaks
+            // First: Need to calculate new missing events
+            const maybeNewMissing = checkNewMissed(
+                state.lastReceived, 
+                action.eventsSinceSubscriptionStart,
+                maybeMissingEvents);
+            const { missingEvents, receivedEvents } = addEventsSimple(action, maybeNewMissing);
+            return returnState(
+                action.type !== 'recover',
+                getNewLastReceived(action, state),
+                missingEvents,
+                receivedEvents
+            )
+        }
+    }
 }
 
-export function reducer(state: CommState, action: CommEvent): CommStateResult {
+const getNewLastReceived = (action: HeartBeatEvent | NotifyEvent | RecoverEvent, state: CommState): number => {
     switch (action.type) {
-        case 'heartbeat-miss':
-            return {
-                error: false,
-                commState: handleHeartbeatMiss(state)
-            };
         case 'heartbeat':
-            return action.eventsEndRange < 0
-                ? { error: true, message: 'eventsSinceSubscriptionStart cannot be less than 0: ' + action.eventsEndRange }
-                : { error: false, commState: handleHeartbeat(state, action.eventsEndRange)}
+        case 'recover':
+            return state.lastReceived;
+        case 'notify':
+            return Math.max(action.events.endRange, state.lastReceived);
+    }
+}
+
+const addEventsSimple = (action: HeartBeatEvent | NotifyEvent | RecoverEvent, priorMissed?: EventList): { receivedEvents?: EventList, missingEvents?: EventList } => {
+    switch (action.type) {
+        case 'heartbeat':
+            return { missingEvents: priorMissed }
         case 'notify':
         case 'recover':
-            const { events } = action;
-            const maybeError: string | undefined =
-                events.endRange < 0
-                    ? 'eventsSinceSubscriptionStart cannot be less than 0: ' + events.endRange
-                    : (events.endRange - events.count) < 0
-                        ? `event indicated negative events. eventsSinceSubscriptionStart=${events.endRange} and eventsInNotification=${events.count}`
-                        : events.count < 0
-                            ? 'eventsInNotification cannt be less than 0: ' + events.count
-                            : undefined;
-            // Both can remove missing events
-            if (!!maybeError) {
+            if (!!priorMissed) {
+                const { removed, result } = removeRangeFromList(priorMissed, action.events)
                 return {
-                    error: true,
-                    message: maybeError
+                    missingEvents: result,
+                    receivedEvents: removed
                 }
             } else {
-                const eventStart = events.endRange - events.count;
-                const maybeNewMissing =
-                    applyToRightLedge<EventRange | undefined>(
-                        { endRange: state.lastReceived, count: state.lastReceived },
-                        events,
-                        // Full overlap, no missing
-                        () => undefined,
-                        // Missing range
-                        (count) => { return { count, endRange: eventStart } },
-                        // Left overhang, we'll take care of this on removal
-                        (_) => undefined
-                    );
-                const maybePriorMissing = applyByMissed<GeneratorRemoveResult>(
-                    state,
-                    (priorMissing) => tryRemoveRangeFromGenerator(priorMissing, events),
-                    () => { return { empty: true } }
-                );
-                const maybeMissing: EventGenerator | undefined = !!maybeNewMissing
-                    ? maybePriorMissing.empty
-                        ? createGenerator(maybeNewMissing) : addRangeToGenerator(maybePriorMissing.generator, maybeNewMissing)
-                    : maybePriorMissing.empty
-                        ? undefined : maybePriorMissing.generator;
-                
-                switch (action.type) {
-                    case 'notify':
-                        return {
-                            error: false,
-                            commState: handleNotify(state, events, maybeMissing)
-                        };
-                    case 'recover':
-                        return {
-                            error: false,
-                            commState: handleRecover(state, events, maybeMissing)
-                        };
-                }
+                return {}
             }
     }
 }
 
-function handleNotify(state: CommState, events: EventRange, maybeMissing?: EventGenerator): CommState {
-    // Only notify can set a new lastReceived
-    // If notification indicates there are more events than we have, set to missed-messages
-    // Can return missed-messages or connected, 
-    // or the initial state (with revised missedMesages) if it's a replay
-    const { lastReceived: priorLastReceived } = state;
-    if (events.endRange > priorLastReceived) {
-        // Connected!
-        const lastReceived = events.endRange;
-        return !!maybeMissing
-            ? {
-                type: 'missed-messages',
-                lastReceived,
-                missingEvents: maybeMissing
-            }
-            : {
-                type: 'connected',
-                lastReceived
-            }
-    } else {
-        // We didn't fix the connection, but it may have been connected
-        return editPreservingConnection(state, priorLastReceived, maybeMissing);
-    }
-}
-
-function handleRecover(state: CommState, events: EventRange, maybeMissing?: EventGenerator): CommState {
-    // Cannot reset lastReceived, or set connection status to connected
-    // Can only modify missingEvents, or break connection if we're missing something
-    const { lastReceived } = state;
-    if (events.endRange > lastReceived) {
-        return !!maybeMissing
-            ? {
-                type: 'broken-and-missed',
-                lastReceived,
-                missingEvents: maybeMissing
-            }
-            : {
-                type: 'broken-connection',
-                lastReceived
-            }
-    } else {
-        // We didn't break the connection, but it may be broken
-        return editPreservingConnection(state, lastReceived, maybeMissing);
-    }
-}
-
-function editPreservingConnection(state: CommState, lastReceived: number, maybeMissing?: EventGenerator): CommState {
-    return !!maybeMissing
-        ? applyByConnected<CommState>(
-            state,
-            // Connected and missing
-            {
-                type: 'missed-messages',
-                lastReceived,
-                missingEvents: maybeMissing
-            },
-            // broken and missing
-            {
-                type: 'broken-and-missed',
-                lastReceived,
-                missingEvents: maybeMissing
-            })
-        : applyByConnected<CommState>(
-            state,
-            // Connected and not missing
-            {
-                type: 'connected',
-                lastReceived
-            },
-            // broken and not missing
-            {
-                type: 'broken-connection',
-                lastReceived
-            });
-}
-
-function handleHeartbeatMiss(state: CommState): CommState {
-    return state.type === 'connected' || state.type === 'broken-connection'
-        ? { type: 'broken-connection', lastReceived: state.lastReceived }
-        : { type: 'broken-and-missed', lastReceived: state.lastReceived, missingEvents: state.missingEvents }
-}
-
-function handleHeartbeat(state: CommState, eventsEndRange: number): CommState {
-    const diffWithLast = eventsEndRange - state.lastReceived;
-    const lastReceived = state.lastReceived;
-    // Reconnects any state, but may have new missed range
-    if (diffWithLast >= 0) {
-        // Reconnects  
-        if (diffWithLast === 0) {
-            const lastReceived = state.lastReceived;
-            return applyByMissed<CommState>(
-                state,
-                (missingEvents) => {
-                    return {
-                        type: 'missed-messages',
-                        lastReceived,
-                        missingEvents
-                    }
-                },
-                () => {
-                    return {
-                        type: 'connected',
-                        lastReceived
-                    }
-                });
-            // Reconnects with new miss
+/**
+ * This functions assumes the following:
+ * - lastReceived does not overlap any event in priorMissingEvents
+ * - eventsSinceSubscriptionStart is greater than the lastKnown event
+ * @param lastReceived 
+ * @param eventsSinceSubscriptionStart 
+ * @param priorMissingEvents 
+ * @returns 
+ */
+function checkNewMissed
+    (lastReceived: number, eventsSinceSubscriptionStart: number, priorMissingEvents?: EventList):
+    EventList | undefined {
+    if (!!priorMissingEvents) {
+        const checkArray = (array: EventList) => array.length === 0
+            ? undefined
+            : array;
+        // Take missingEvents into account. Need to check which property knows of a greater event
+        const missingCopy = priorMissingEvents.slice();
+        const lastMissedEntry = missingCopy[missingCopy.length - 1];
+        const lastMissed = lastMissedEntry.endRange;
+        // Assume lastMissed !== lastReceived. We shouldn't generate that
+        if (lastMissed > lastReceived) {
+            // Need to append to lastMissedEntry
+            const newMissing: EventRange = {
+                endRange: eventsSinceSubscriptionStart,
+                count: eventsSinceSubscriptionStart - getStart(lastMissedEntry)
+            };
+            missingCopy.pop();
+            missingCopy.push(newMissing);
+            return checkArray(missingCopy)
         } else {
-            const newMissed: EventRange = {
-                endRange: eventsEndRange,
-                count: diffWithLast
-            };
-            const missingEvents = applyByMissed<EventGenerator>(
-                state,
-                (priorMisses) => addRangeToGenerator(priorMisses, newMissed),
-                () => createGenerator(newMissed)
-            );
-            return {
-                type: 'missed-messages',
-                lastReceived,
-                missingEvents
-            };
+            // Need to append a new entry to missingCopy
+            const newMissing = {
+                endRange: eventsSinceSubscriptionStart,
+                count: eventsSinceSubscriptionStart - lastReceived
+            }
+            missingCopy.push(newMissing);
+            return checkArray(missingCopy)
         }
-        // Replayed heartbeat
     } else {
-        return state;
+        // Just check lastReceived vs sinceStart...
+        const sinceStartToReceived = eventsSinceSubscriptionStart - lastReceived;
+        return sinceStartToReceived > 0
+            ? [{ endRange: eventsSinceSubscriptionStart, count: sinceStartToReceived }]
+            : undefined;
     }
+}
+
+function checkLastKnown(missingEvents: EventList, lastReceived: number): number {
+    const missingLength = missingEvents.length;
+    return missingLength < 1
+        ? lastReceived
+        : Math.max(missingEvents[missingLength - 1].endRange, lastReceived);
 }
 
 export function applyByConnected<T>(
@@ -249,7 +206,7 @@ export function applyByConnected<T>(
 
 export function applyByMissed<T>(
     state: CommState,
-    applyMissed: (missed: EventGenerator) => T,
+    applyMissed: (missed: EventList) => T,
     applyNoMiss: () => T
 ): T {
     switch (state.type) {
@@ -259,256 +216,5 @@ export function applyByMissed<T>(
         case 'missed-messages':
         case 'broken-and-missed':
             return applyMissed(state.missingEvents);
-    }
-}
-
-function* createGenerator(create: EventRange): EventGenerator {
-    yield create;
-    return create.count;
-}
-
-function* addRangeToGenerator(existing: EventGenerator, add: EventRange): EventGenerator {
-    let result = existing.next();
-    while (!result.done) {
-        yield result.value;
-        result = existing.next();
-    }
-    yield add;
-    return result.value + add.count;
-}
-
-type EmptyGenerator = {
-    empty: true
-}
-type NonemptyGenerator = {
-    empty: false,
-    generator: EventGenerator
-}
-type GeneratorRemoveResult = EmptyGenerator | NonemptyGenerator;
-
-function tryRemoveRangeFromGenerator(existing: EventGenerator, remove: EventRange): GeneratorRemoveResult {
-    const newGenerator = removeRangeFromGenerator(existing, remove);
-    const firstEntry = newGenerator.next();
-    return !!firstEntry.done
-        ? { empty: true }
-        : { empty: false, generator: removeRangeFromGenerator(existing, remove) }
-};
-
-function* removeRangeFromGenerator(existing: EventGenerator, remove: EventRange): EventGenerator {
-    let result = existing.next();
-    // Copy input, make mutable while we carve away
-    let toRemove: EventRange | undefined = { ...remove };
-    // Keep track of removals for aggregate count
-    let removalCount: number = 0;
-    while (!result.done) {
-        const range = result.value;
-        if (typeof toRemove !== 'undefined') {
-            const { removal, yieldedRange } = removeRangeForward(range, toRemove);
-            switch (removal.type) {
-                case 'none':
-                    break;
-                case 'partial':
-                    const { newRemove, count } = removal;
-                    removalCount = removalCount + count;
-                    toRemove = newRemove;
-                    break;
-                case 'full':
-                    removalCount = removalCount + removal.count;
-                    break;
-            }
-
-            switch (yieldedRange.type) {
-                case 'none':
-                    break;
-                case 'one':
-                    yield yieldedRange.newRange;
-                    break;
-                case 'two':
-                    const { firstRange, secondRange } = yieldedRange;
-                    yield firstRange;
-                    yield secondRange;
-                    break;
-            }
-        } else {
-            yield result.value
-        }
-        result = existing.next();
-    }
-    return result.value - removalCount;
-}
-
-// Types for removals
-type RemovalWithCount = {
-    count: number
-}
-type NoRemoval = {
-    type: 'none'
-}
-type FullRemoval = RemovalWithCount & {
-    type: 'full'
-}
-type PartialRemoval = RemovalWithCount & {
-    type: 'partial',
-    newRemove: EventRange
-}
-type Removal = NoRemoval | FullRemoval | PartialRemoval;
-
-// Types for yielded ranges
-type NoRange = {
-    type: 'none'
-}
-type OneRange = {
-    type: 'one'
-    newRange: EventRange
-}
-type TwoRanges = {
-    type: 'two',
-    firstRange: EventRange,
-    secondRange: EventRange
-}
-type YieldedRange = NoRange | OneRange | TwoRanges;
-
-// Type for RemovalResult
-type RemovalResult = {
-    yieldedRange: YieldedRange,
-    removal: Removal
-}
-
-function applyToRightLedge<T>(
-    range: EventRange,
-    remove: EventRange,
-    applyZero: () => T,
-    applyPositive: (value: number) => T,
-    applyNegative: (absolute: number) => T
-): T {
-    const rightLedge = remove.endRange - range.endRange;
-    if (rightLedge === 0) {
-        return applyZero();
-    } else if (rightLedge > 0) {
-        return applyPositive(rightLedge);
-    } else {
-        return applyNegative(-rightLedge);
-    }
-}
-
-function removeRangeForward(range: EventRange, remove: EventRange): RemovalResult {
-    const startRange = range.endRange - range.count;
-    const startRemove = remove.endRange - remove.count;
-    // Check if it's an early or late miss
-    if ((remove.endRange < startRange) || (startRemove > range.endRange)) {
-        return {
-            removal: {
-                type: 'none'
-            },
-            yieldedRange: {
-                type: 'one',
-                newRange: range
-            }
-        }
-        // Else there's an overlap. Start searching from the left
-    } else {
-        // Check if removal overlaps left of range
-        if (startRemove <= startRange) {
-            return applyToRightLedge<RemovalResult>(range, remove,
-                // No leftover, complete removal
-                () => {
-                    return {
-                        removal: {
-                            type: 'full',
-                            count: range.count //Use range b/c of left overhang
-                        },
-                        yieldedRange: {
-                            type: 'none'
-                        }
-                    }
-                },
-                // Partial removal, no yield 
-                (val) => {
-                    return {
-                        removal: {
-                            type: 'partial',
-                            count: range.count,
-                            newRemove: {
-                                count: val,
-                                endRange: remove.endRange
-                            }
-                        },
-                        yieldedRange: {
-                            type: 'none'
-                        }
-                    }
-                },
-                // Full removal, yield single section
-                (abs) => {
-                    return {
-                        removal: {
-                            type: 'full',
-                            count: remove.endRange - startRange
-                        },
-                        yieldedRange: {
-                            type: 'one',
-                            newRange: {
-                                endRange: range.endRange,
-                                count: abs
-                            }
-                        }
-                    }
-                });
-
-            // If it doesn't, we know it's not a miss, but will have at least one newRange
-        } else {
-            const newRange: EventRange = {
-                endRange: startRemove,
-                count: startRemove - startRange
-            }
-            return applyToRightLedge<RemovalResult>(range, remove,
-                // Full removal with single yielded range
-                () => {
-                    return {
-                        removal: {
-                            type: 'full',
-                            count: remove.count //Use remove b/c no left overhang
-                        },
-                        yieldedRange: {
-                            type: 'one',
-                            newRange
-                        }
-                    }
-                },
-                // Partial removal, single yield 
-                (val) => {
-                    return {
-                        removal: {
-                            type: 'partial',
-                            count: range.endRange - startRemove,
-                            newRemove: {
-                                count: val,
-                                endRange: remove.endRange
-                            }
-                        },
-                        yieldedRange: {
-                            type: 'one',
-                            newRange
-                        }
-                    }
-                },
-                // Full removal, yield two side sections
-                (abs) => {
-                    return {
-                        removal: {
-                            type: 'full',
-                            count: remove.count
-                        },
-                        yieldedRange: {
-                            type: 'two',
-                            secondRange: {
-                                endRange: range.endRange,
-                                count: abs
-                            },
-                            firstRange: newRange
-                        }
-                    }
-                });
-        }
     }
 }

--- a/src/models/EventRange.ts
+++ b/src/models/EventRange.ts
@@ -1,0 +1,160 @@
+export type EventRange = { endRange: number, count: number };
+export type EventList = EventRange[];
+
+export type RemovalResult = { result?: EventList, removed?: EventList }
+
+export function getStart({ count, endRange }: EventRange): number {
+    return endRange - count;
+}
+
+export function removeRangeFromList(list: EventList, remove: EventRange): RemovalResult {
+    const noRemoval = (result: EventList): RemovalResult => {
+        return result.length === 0
+            ? {}
+            : { result };
+    };
+    const removal = (result: EventList, removed: EventList): RemovalResult => {
+        return result.length === 0
+            ? removed.length === 0
+                ? {}
+                : { removed }
+            : removed.length === 0
+                ? { result }
+                : { removed, result };
+    };
+    const _length = list.length;
+    const removeStart = getStart(remove);
+    const headIndex = (_length - 1) - list.slice().reverse().findIndex(entry => removeStart >= entry.endRange);
+    const tailIndex = list.findIndex(entry => remove.endRange <= getStart(entry));
+
+    // Handle no overlaps
+    if ((headIndex === _length && tailIndex === 0) ||
+        (headIndex === 0 && tailIndex === -1)) {
+        return noRemoval(list);
+    }
+
+    const { resultHead, baseHeadIndex }: { resultHead: EventList, baseHeadIndex: number }
+        = headIndex === _length
+            ? { resultHead: [], baseHeadIndex: 0 }
+            : { resultHead: list.slice(0, headIndex + 1), baseHeadIndex: headIndex + 1 }
+
+    const { resultTail, baseTailIndex }: { resultTail: EventList, baseTailIndex: number }
+        = tailIndex === -1
+            ? { resultTail: [], baseTailIndex: _length - 1 }
+            : { resultTail: list.slice(tailIndex - 1), baseTailIndex: tailIndex - 1 }
+
+    const baseHead: EventRange = list[baseHeadIndex];
+    const baseTail: EventRange = list[baseTailIndex];
+
+    const leftOverhang = getLeftOverhang(baseHead, remove);
+    const rightOverhang = getRightOverhang(baseTail, remove);
+
+    if (baseTailIndex === baseHeadIndex) {
+        const overlappedRange = baseHead;
+        const overlapStart = getStart(baseHead);
+        let removedRange: EventRange;
+        // Need to handle 4 undershot scenarios
+        if (leftOverhang.type === 'undershot' &&
+            rightOverhang.type === 'undershot') {
+            const rightUndershot = rightOverhang.undershot;
+            const leftUndershot = leftOverhang.undershot;
+            const startRight = getStart(rightUndershot);
+            resultHead.push(leftUndershot);
+            resultTail.unshift(rightUndershot);
+            removedRange = {
+                endRange: startRight,
+                count: startRight - leftUndershot.endRange
+            };
+        } else if (leftOverhang.type === 'undershot') {
+            const leftUndershot = leftOverhang.undershot;
+            resultHead.push(leftUndershot);
+            removedRange = {
+                endRange: overlappedRange.endRange,
+                count: overlappedRange.endRange - leftUndershot.endRange
+            };
+        } else if (rightOverhang.type === 'undershot') {
+            const rightUndershot = rightOverhang.undershot;
+            const rightStart = getStart(rightUndershot);
+            resultTail.unshift(rightUndershot);
+            removedRange = {
+                endRange: rightStart,
+                count: rightStart - overlapStart
+            };
+        } else {
+            removedRange = baseHead;
+        }
+        return removal([...resultHead, ...resultTail], [removedRange]);
+    } else {
+        const removed = list.slice(baseHeadIndex + 1, baseTailIndex - 1);
+        // Can handle left and right overhangs independently
+        // We overlap more than one range. Check both overhangs
+        if (leftOverhang.type === 'undershot') {
+            const { undershot } = leftOverhang;
+            resultHead.push(undershot);
+            const { endRange } = baseHead;
+            removed.unshift({
+                endRange,
+                count: endRange - undershot.endRange
+            });
+        } else {
+            removed.unshift(baseHead);
+        }
+        if (rightOverhang.type === 'undershot') {
+            const { undershot } = rightOverhang;
+            resultTail.unshift(undershot);
+            const endRange = getStart(undershot);
+            removed.push({
+                endRange,
+                count: endRange - getStart(baseTail)
+            });
+        }
+        else {
+            removed.push(baseTail);
+        }
+        return removal([...resultHead, ...resultTail], removed);
+    }
+}
+
+// Types for overhangs
+type Exact = { type: 'exact' };
+type Overshot = { type: 'overshot', overshot: EventRange };
+type Undershot = { type: 'undershot', undershot: EventRange };
+type OverhangResult = Exact | Overshot | Undershot;
+const getRightOverhang = (left: EventRange, right: EventRange): OverhangResult => {
+    const overhang = right.endRange - left.endRange;
+    return overhang > 0
+        ? {
+            type: 'overshot', overshot: {
+                endRange: right.endRange,
+                count: overhang
+            }
+        }
+        : overhang === 0
+            ? { type: 'exact' }
+            : {
+                type: 'undershot', undershot: {
+                    endRange: left.endRange,
+                    count: -overhang
+                }
+            };
+};
+const getLeftOverhang = (right: EventRange, left: EventRange): OverhangResult => {
+    const rightStart = getStart(right);
+    const leftStart = getStart(left);
+    const overhang = leftStart - rightStart;
+    return overhang > 0
+        ? {
+            type: 'undershot', undershot: {
+                endRange: leftStart,
+                count: overhang
+            }
+        }
+        : overhang === 0
+            ? { type: 'exact' }
+            : {
+                type: 'overshot', overshot: {
+                    endRange: rightStart,
+                    count: -overhang
+                }
+            };
+};

--- a/src/test/EventRange.test.ts
+++ b/src/test/EventRange.test.ts
@@ -1,0 +1,221 @@
+import { EventRange, removeRangeFromList, RemovalResult } from '../models/EventRange';
+
+type RemoveScenario = {
+    remove: EventRange,
+    list: EventRange[],
+    expected: RemovalResult
+}
+
+const processRemove = (desc: string, sc: RemoveScenario) => {
+    it(desc, () => {
+        const { list, remove, expected } = sc;
+        const actual = removeRangeFromList(list, remove);
+        expect(actual).toEqual(expected);
+    });
+}
+
+describe('Test removing eventRange from a list', () => {
+    processRemove('Removal N/A if we did not have the event (too early)', {
+        list: [{
+            endRange: 2,
+            count: 1
+        }],
+        remove: {
+            endRange: 1,
+            count: 1
+        },
+        expected: {
+            result: [{
+                endRange: 2,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Removal N/A if we did not have the event (too late)', {
+        list: [{
+            endRange: 2,
+            count: 1
+        }],
+        remove: {
+            endRange: 3,
+            count: 1
+        },
+        expected: {
+            result: [{
+                endRange: 2,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Can remove an entire range', {
+        list: [{
+            endRange: 2,
+            count: 1
+        }],
+        remove: {
+            endRange: 2,
+            count: 1
+        },
+        expected: {
+            removed: [{
+                endRange: 2,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Removal can split a range', {
+        list: [{
+            endRange: 3,
+            count: 3
+        }],
+        remove: {
+            endRange: 2,
+            count: 1
+        },
+        expected: {
+            result: [{
+                endRange: 1,
+                count: 1
+            }, {
+                endRange: 3,
+                count: 1
+            }],
+            removed: [{
+                endRange: 2,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Removal ignores left overhang', {
+        list: [{
+            endRange: 3,
+            count: 2
+        }],
+        remove: {
+            endRange: 2,
+            count: 2
+        },
+        expected: {
+            result: [{
+                endRange: 3,
+                count: 1
+            }],
+            removed: [{
+                endRange: 2,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Removal ignores right overhang', {
+        list: [{
+            endRange: 2,
+            count: 2
+        }],
+        remove: {
+            endRange: 3,
+            count: 2
+        },
+        expected: {
+            result: [{
+                endRange: 1,
+                count: 1
+            }],
+            removed: [{
+                endRange: 2,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Can remove beginning of a range', {
+        list: [{
+            endRange: 2,
+            count: 2
+        }],
+        remove: {
+            endRange: 1,
+            count: 1
+        },
+        expected: {
+            result: [{
+                endRange: 2,
+                count: 1
+            }],
+            removed: [{
+                endRange: 1,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Can remove end of a range', {
+        list: [{
+            endRange: 2,
+            count: 2
+        }],
+        remove: {
+            endRange: 2,
+            count: 1
+        },
+        expected: {
+            result: [{
+                endRange: 1,
+                count: 1
+            }],
+            removed: [{
+                endRange: 2,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Can remove end of a terminal range in a multi-range array, ignoring overhang', {
+        list: [{
+            endRange: 2,
+            count: 1
+        }, {
+            endRange: 5,
+            count: 2
+        }],
+        remove: {
+            endRange: 6,
+            count: 2
+        },
+        expected: {
+            result: [{
+                endRange: 2,
+                count: 1
+            }, {
+                endRange: 4,
+                count: 1
+            }],
+            removed: [{
+                endRange: 5,
+                count: 1
+            }]
+        }
+    });
+    processRemove('Can remove beginning of a beginning range in a multi-range array, ignoring overhang', {
+        list: [{
+            endRange: 3,
+            count: 2
+        }, {
+            endRange: 5,
+            count: 1
+        }],
+        remove: {
+            endRange: 2,
+            count: 2
+        },
+        expected: {
+            result: [{
+                endRange: 3,
+                count: 1
+            }, {
+                endRange: 5,
+                count: 1
+            }],
+            removed: [{
+                endRange: 2,
+                count: 1
+            }]
+        }
+    });
+});


### PR DESCRIPTION
### Overview
Created a state machine for handling different types of events as a client (events as in receiving SubscriptionStatus resources).

Under the Playground scenario, the panel _Manually trigger communication events_ contains a UI for raising events to the state machine.

### Defining State
Subscription clients (subscribers) are primarily concerned with the following:

- Assessing the current connection to the server (notifier)
- Noticing any missed events (actual numbered server events) that need follow up with $events, $status or another mechanism
- Processing any newly received server events

The easiest way to encapsulate this was using 4 properties:

1. A `type` that says whether the client's connection to the server is broken or not
2. `lastReceived` - The last server event the client received, either from a notification or a $events call
3. `missingEvents` -The list of server events the client knows happened, but hasn't received
4. `receivedEvents` - The list of server events the client just received. We do not keep an exhaustive list of all received events, since a client can process these as they are received. Note that if an event is re-sent to the client, it will not be re-surfaced here.

### Defining Events (Actions upon the Client's State, not specific server events)
There are 4 types of events that can be raised to the client:
1. `notify` - A notification sent to the client with included server events
2. `heartbeat` - A notification sent to the client without any included events 
3. `recover` - The outcome of a `$events` call with included server events
4. `heartbeat-miss` - To represent the client's heartbeat-period being exceeded 

### State Machine Algorithm
This is the rough algorithm I used to take an existing state and a new event (action) and create a new state:

1. Compare `eventsSinceSubscriptionStart` to the last received value, if it's less than or equal, proceed to step 3
2. Use `eventsSinceSubscriptionStart` to calculate a new list of missing events based on the previous state. Effectively ignore any included events until after this step
3. If the event included any server events, try to add those to the list of missing events. This list will either be new (calculated from step 2) or existing (if skipped).